### PR TITLE
Fix windows amd64 build error in dpi_bypass

### DIFF
--- a/transport/internet/dpi_bypass.go
+++ b/transport/internet/dpi_bypass.go
@@ -57,7 +57,7 @@ func ApplyDPIBypassOptions(fd uintptr, options *DPIBypassOptions) error {
 	
 	// TCP_NODELAY - отключаем алгоритм Nagle для уменьшения задержек
 	if options.TCPNoDelay {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_NODELAY, 1); err != nil {
+		if err := setSockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_NODELAY, 1); err != nil {
 			// Игнорируем ошибку, продолжаем применять другие опции
 		}
 	}
@@ -65,31 +65,31 @@ func ApplyDPIBypassOptions(fd uintptr, options *DPIBypassOptions) error {
 	// TCP_QUICKACK - быстрое подтверждение пакетов
 	if options.TCPQuickAck {
 		// TCP_QUICKACK = 12 (Linux specific)
-		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, 12, 1)
+		setSockoptInt(fd, syscall.IPPROTO_TCP, 12, 1)
 	}
 	
 	// Устанавливаем размер окна
 	if options.WindowSize > 0 {
-		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, options.WindowSize)
-		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, options.WindowSize)
+		setSockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, options.WindowSize)
+		setSockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, options.WindowSize)
 	}
 	
 	// TCP_USER_TIMEOUT - таймаут для неподтвержденных данных
 	if options.TCPUserTimeout > 0 {
 		// TCP_USER_TIMEOUT = 18 (Linux specific)
-		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, 18, options.TCPUserTimeout)
+		setSockoptInt(fd, syscall.IPPROTO_TCP, 18, options.TCPUserTimeout)
 	}
 	
 	// TCP_FASTOPEN - ускоренное открытие соединения
 	if options.TCPFastOpen {
 		// TCP_FASTOPEN = 23 (Linux specific)
-		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, 23, 1)
+		setSockoptInt(fd, syscall.IPPROTO_TCP, 23, 1)
 	}
 	
 	// MSS - Maximum Segment Size
 	if options.MSS > 0 {
 		// TCP_MAXSEG = 2
-		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, 2, options.MSS)
+		setSockoptInt(fd, syscall.IPPROTO_TCP, 2, options.MSS)
 	}
 	
 	return nil
@@ -146,7 +146,7 @@ func (dbc *DPIBypassConn) writeTTLManipulated(data []byte) (int, error) {
 			
 			// Устанавливаем низкий TTL
 			rawConn.Control(func(fd uintptr) {
-				setTTLErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, dbc.options.TTLFake)
+				setTTLErr = setSockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_TTL, dbc.options.TTLFake)
 			})
 			
 			if setTTLErr == nil {
@@ -160,7 +160,7 @@ func (dbc *DPIBypassConn) writeTTLManipulated(data []byte) (int, error) {
 				
 				// Восстанавливаем нормальный TTL
 				rawConn.Control(func(fd uintptr) {
-					syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, dbc.options.TTLReal)
+					setSockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_TTL, dbc.options.TTLReal)
 				})
 			}
 		}

--- a/transport/internet/dpi_bypass_unix.go
+++ b/transport/internet/dpi_bypass_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package internet
+
+import "syscall"
+
+// setSockoptInt is a platform-specific wrapper for setting socket options
+func setSockoptInt(fd uintptr, level, opt, value int) error {
+	return syscall.SetsockoptInt(int(fd), level, opt, value)
+}

--- a/transport/internet/dpi_bypass_windows.go
+++ b/transport/internet/dpi_bypass_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package internet
+
+import "syscall"
+
+// setSockoptInt is a platform-specific wrapper for setting socket options
+func setSockoptInt(fd uintptr, level, opt, value int) error {
+	return syscall.SetsockoptInt(syscall.Handle(fd), level, opt, value)
+}


### PR DESCRIPTION
Fixes Windows build error by using platform-specific `syscall.SetsockoptInt` calls.

The `transport/internet/dpi_bypass.go` file was failing to build on Windows (amd64) because `syscall.SetsockoptInt` expects a `syscall.Handle` type for the file descriptor argument on Windows, while the code was passing an `int`. This PR introduces platform-specific wrapper functions (`setSockoptInt`) using build tags to correctly cast the file descriptor (`uintptr`) to `syscall.Handle` on Windows and `int` on Unix-like systems, resolving the type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-94b2acb4-7d29-4365-ba30-dd764cef44a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94b2acb4-7d29-4365-ba30-dd764cef44a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

